### PR TITLE
Fix Block::getClassObject env options

### DIFF
--- a/src/models/Block.php
+++ b/src/models/Block.php
@@ -27,10 +27,44 @@ class Block extends ActiveRecord
     /**
      * Returns the origin block object based on the current active record entry.
      *
+     * @param integer $id The context id, the cms_nav_item_page_block_item unique id
+     * @param string $context admin or frontend
+     * @param mixed $pageObject
      * @return BlockInterface
      */
-    public function getClassObject()
+    public function getClassObject($id = null, $context = null, $pageObject = null)
     {
-        return Yii::createObject(['class' => $this->class]);
+        return self::createObject($this->class, $this->id, $id, $context, $pageObject);
+    }
+
+    /**
+     * Creates the block object and stores the object within a static block container.
+     *
+     * @param string $class
+     * @param integer $blockId The id of the cms_block table
+     * @param integer $id The context id, the cms_nav_item_page_block_item unique id
+     * @param string $context admin or frontend
+     * @param mixed $pageObject
+     * @return \luya\cms\base\BlockInterface
+     */
+    public static function createObject($class, $blockId, $id, $context, $pageObject = null)
+    {
+        if (!class_exists($class)) {
+            return false;
+        }
+
+        /** @var BlockInterface $object */
+        $object = Yii::createObject([
+            'class' => $class,
+        ]);
+
+        $object->setEnvOption('id', $id);
+        $object->setEnvOption('blockId', $blockId);
+        $object->setEnvOption('context', $context);
+        $object->setEnvOption('pageObject', $pageObject);
+
+        $object->setup();
+
+        return $object;
     }
 }

--- a/src/models/Block.php
+++ b/src/models/Block.php
@@ -6,6 +6,17 @@ use luya\cms\base\BlockInterface;
 use Yii;
 use yii\db\ActiveRecord;
 
+/**
+ * Class Block
+ * @package luya\headless\cms\api\models
+ *
+ * @property int $id
+ * @property int $group_id
+ * @property string $class
+ * @property bool $is_disabled
+ *
+ * @property-read BlockInterface $classObject
+ */
 class Block extends ActiveRecord
 {
     public static function tableName()

--- a/src/models/Container.php
+++ b/src/models/Container.php
@@ -5,6 +5,19 @@ namespace luya\headless\cms\api\models;
 use luya\helpers\ArrayHelper;
 use yii\db\ActiveRecord;
 
+/**
+ * Class Container
+ * @package luya\headless\cms\api\models
+ *
+ * @property int $id
+ * @property int $website_id
+ * @property string $name
+ * @property string $alias
+ * @property bool $is_deleted
+ *
+ * @property Nav[] $navs
+ * @property NavItem[] $items
+ */
 class Container extends ActiveRecord
 {
     public static function tableName()
@@ -20,8 +33,8 @@ class Container extends ActiveRecord
     public function getNavs()
     {
         return $this->hasMany(Nav::class, ['nav_container_id' => 'id'])
-        ->andOnCondition(['is_offline' => false, 'is_draft' => false, 'cms_nav.is_deleted' => false])
-        ->orderBy(['sort_index' => SORT_ASC]);
+            ->andOnCondition(['is_offline' => false, 'is_draft' => false, 'cms_nav.is_deleted' => false])
+            ->orderBy(['sort_index' => SORT_ASC]);
     }
 
     public function getItems()
@@ -56,13 +69,13 @@ class Container extends ActiveRecord
                     'children' => $this->buildTree($items, $item->id, $currentPath),
                 ];
 
-                $newItem['has_children'] = count($newItem['children']) > 0 ? true : false;
+                $newItem['has_children'] = count($newItem['children']) > 0;
                 $result[] = $newItem;
             }
         }
 
         ArrayHelper::multisort($result, 'index', SORT_ASC);
-      
+
         return $result;
     }
 }

--- a/src/models/Layout.php
+++ b/src/models/Layout.php
@@ -5,6 +5,15 @@ namespace luya\headless\cms\api\models;
 use luya\behaviors\JsonBehavior;
 use yii\db\ActiveRecord;
 
+/**
+ * Class Layout
+ * @package luya\headless\cms\api\models
+ *
+ * @property int $id
+ * @property string $name
+ * @property array|null $json_config
+ * @property string $view_file
+ */
 class Layout extends ActiveRecord
 {
     public static function tableName()
@@ -18,11 +27,11 @@ class Layout extends ActiveRecord
             [
                 'class' => JsonBehavior::class,
                 'attributes' => ['json_config'],
-            ]
+            ],
         ];
     }
 
-    public function getPlaholdersList()
+    public function getPlaceholdersList()
     {
         $list = [];
         foreach ($this->json_config['placeholders'] as $row) {

--- a/src/models/Nav.php
+++ b/src/models/Nav.php
@@ -6,6 +6,25 @@ use luya\admin\models\Property as ModelsProperty;
 use luya\cms\models\Property;
 use yii\db\ActiveRecord;
 
+/**
+ * Class Nav
+ * @package luya\headless\cms\api\models
+ * @property int $id
+ * @property int $nav_container_id
+ * @property int $parent_nav_id
+ * @property int $sort_index
+ * @property bool $is_deleted
+ * @property bool $is_hidden
+ * @property bool $is_home
+ * @property bool $is_offline
+ * @property bool $is_draft
+ * @property string $layout_file
+ * @property int $publish_from
+ * @property int $publish_till
+ *
+ * @property NavItem[] $navItems
+ * @property Property[] $properties
+ */
 class Nav extends ActiveRecord
 {
     public static function tableName()
@@ -48,6 +67,6 @@ class Nav extends ActiveRecord
             }
         }
 
-        return (object) $values;
+        return (object)$values;
     }
 }

--- a/src/models/NavItem.php
+++ b/src/models/NavItem.php
@@ -4,6 +4,31 @@ namespace luya\headless\cms\api\models;
 
 use yii\db\ActiveRecord;
 
+/**
+ * Class NavItem
+ * @package luya\headless\cms\api\models
+ *
+ * @property int $id
+ * @property int $nav_id
+ * @property int $lang_id
+ * @property int $nav_item_type
+ * @property int $nav_item_type_id
+ * @property int $create_user_id
+ * @property int $update_user_id
+ * @property int $timestamp_create
+ * @property int $timestamp_update
+ * @property string $title
+ * @property string $alias
+ * @property string $description
+ * @property string $keywords
+ * @property string $title_tag
+ * @property int $image_id
+ * @property bool $is_url_strict_parsing_disabled
+ * @property bool $is_cacheable
+ *
+ * @property Nav $nav
+ * @property NavItemPage $currentPage
+ */
 class NavItem extends ActiveRecord
 {
     public static function tableName()

--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -79,7 +79,7 @@ class NavItemPage extends ActiveRecord
                 $placeholders = $this->buildTree($blocks, $block->id, $block->placeholder_var);
 
                 /** @var BlockInterface $object */
-                $object = $block->block->getClassObject();
+                $object = $block->block->getClassObject($block->id, 'frontend');
                 $object->setVarValues($block->getEnsuredValues());
                 $object->setCfgValues($block->getEnsuredConfigs());
 

--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -8,6 +8,22 @@ use luya\helpers\Inflector;
 use ReflectionClass;
 use yii\db\ActiveRecord;
 
+/**
+ * Class NavItemPage
+ * @package luya\headless\cms\api\models
+ *
+ * @property int $id
+ * @property int $layout_id
+ * @property int $nav_item_id
+ * @property int $timestamp_create
+ * @property int $create_user_id
+ * @property string $version_alias
+ * @property int $timestamp_update
+ *
+ * @property NavItem $navItem
+ * @property Layout $layout
+ * @property PageBlock[] $blocks
+ */
 class NavItemPage extends ActiveRecord
 {
     public static function tableName()
@@ -38,16 +54,23 @@ class NavItemPage extends ActiveRecord
     public function getContent()
     {
         $result = [];
-        foreach ($this->layout->getPlaholdersList() as $placeholderName) {
+        foreach ($this->layout->getPlaceholdersList() as $placeholderName) {
 
             $placholders = $this->buildTree($this->blocks, 0, $placeholderName);
-            
+
             $result[$placeholderName] = array_key_exists($placeholderName, $placholders) ? $placholders[$placeholderName] : [];
         }
 
         return $result;
     }
 
+    /**
+     * @param PageBlock[] $blocks
+     * @param $prevId
+     * @param $placeholderName
+     * @return array
+     * @throws \ReflectionException
+     */
     private function buildTree(array $blocks, $prevId, $placeholderName)
     {
         $result = [];
@@ -73,7 +96,7 @@ class NavItemPage extends ActiveRecord
                     'cfgs' => $block->getEnsuredConfigs(),
                     'extras' => $object->getExtraVarValues(),
                 ];
-                
+
                 if ($object->getIsContainer()) {
                     // ensure all placeholders exists
                     foreach ($object->getConfigPlaceholdersExport() as $placeholderName) {
@@ -85,8 +108,8 @@ class NavItemPage extends ActiveRecord
             }
         }
 
-        foreach ($result as $placederVar => $items) {
-            ArrayHelper::multisort($result[$placederVar], 'index', SORT_ASC);
+        foreach ($result as $placeholderVar => $items) {
+            ArrayHelper::multisort($result[$placeholderVar], 'index', SORT_ASC);
         }
 
         return $result;

--- a/src/models/PageBlock.php
+++ b/src/models/PageBlock.php
@@ -5,6 +5,28 @@ namespace luya\headless\cms\api\models;
 use luya\behaviors\JsonBehavior;
 use yii\db\ActiveRecord;
 
+/**
+ * Class PageBlock
+ * @package luya\headless\cms\api\models
+ *
+ * @property int $id
+ * @property int $block_id
+ * @property string $placeholder_var
+ * @property int $nav_item_page_id
+ * @property int $prev_id
+ * @property array|null $json_config_values
+ * @property array|null $json_config_cfg_values
+ * @property bool $is_dirty
+ * @property int $create_user_id
+ * @property int $update_user_id
+ * @property int $timestamp_create
+ * @property int $timestamp_update
+ * @property int $sort_index
+ * @property bool $is_hidden
+ * @property string $variation
+ *
+ * @property Block $block
+ */
 class PageBlock extends ActiveRecord
 {
     public static function tableName()
@@ -23,7 +45,7 @@ class PageBlock extends ActiveRecord
             [
                 'class' => JsonBehavior::class,
                 'attributes' => ['json_config_values', 'json_config_cfg_values'],
-            ]
+            ],
         ];
     }
 


### PR DESCRIPTION
### What are you changing/introducing

Fixed this issue: luyadev/luya-headless-cms-api#8

I've fixed `\luya\headless\cms\api\models\Block::getClassObject` method, like how is it done in CMS model (`\luya\cms\models\Block::getObject`).

Also was added PHPDocs for all AR models, fix some typo.

### What is the reason for changing/introducing



### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | 
| Fixed issues  | luyadev/luya-headless-cms-api#8
