### PR TITLE
Fixed NavItemPage::buildTree() method

### DIFF
--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -75,6 +75,7 @@ class NavItemPage extends ActiveRecord
     {
         $result = [];
         foreach ($blocks as $block) {
+            /** @var PageBlock $block */
             if ($block->prev_id == $prevId) {
                 $placeholders = $this->buildTree($blocks, $block->id, $block->placeholder_var);
 

--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -85,6 +85,15 @@ class NavItemPage extends ActiveRecord
 
                 $reflect = new ReflectionClass($object);
 
+                if ($object->getIsContainer()) {
+                    // ensure all placeholders exists
+                    $insertedHolders = [];
+                    foreach ($object->getConfigPlaceholdersExport() as $placeholderName) {
+                        $insertedHolders[$placeholderName['var']] = array_key_exists($placeholderName['var'], $placeholders) ? $placeholders[$placeholderName['var']] : [];
+                    }
+                    $object->setPlaceholderValues($insertedHolders);
+                }
+
                 $newItem = [
                     'id' => $block->id,
                     'index' => $block->sort_index,
@@ -98,10 +107,7 @@ class NavItemPage extends ActiveRecord
                 ];
 
                 if ($object->getIsContainer()) {
-                    // ensure all placeholders exists
-                    foreach ($object->getConfigPlaceholdersExport() as $placeholderName) {
-                        $newItem['placeholders'][$placeholderName['var']] = array_key_exists($placeholderName['var'], $placeholders) ? $placeholders[$placeholderName['var']] : [];
-                    }
+                    $newItem['placeholders'] = $insertedHolders;
                 }
 
                 $result[$block->placeholder_var][] = $newItem;


### PR DESCRIPTION
### What are you changing/introducing

Render placeholders before create $newItem var, so allow to manipulate placeholders content before getting extra vars.
And added `$object->setPlaceholderValues($insertedHolders);`, so block will know what placeholders it has.

### What is the reason for changing/introducing

There was no way to get placeholders in extraVars() method. Now it is possible. And block will know what placeholders it has.


Is it right solution? What do you think?


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | mb
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | 
